### PR TITLE
Fix loading locale

### DIFF
--- a/src/entries/native.js
+++ b/src/entries/native.js
@@ -1,7 +1,7 @@
 import app from '../ui/native.js'
 import Controller from '../lib/Controller'
 
-window['floccus'] = app
+app()
 
 const onload = async() => {
   const controller = await Controller.getSingleton()

--- a/src/entries/options.js
+++ b/src/entries/options.js
@@ -1,3 +1,3 @@
 import app from '../ui'
 
-window['floccus'] = app
+app()

--- a/src/lib/native/I18n.ts
+++ b/src/lib/native/I18n.ts
@@ -25,7 +25,7 @@ export default class I18n {
   async load():Promise<void> {
     for (const locale of this.locales) {
       try {
-        this.messages = (await import(`../../../dist/_locales/${locale}.json`)).default
+        this.messages = (await import(`../../../dist/_locales/${locale.replace('-', '_')}.json`)).default
         this.locale = locale
         break
       } catch (error) {

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -10,17 +10,17 @@ import {i18n} from '../lib/native/I18n'
 Vue.mixin(i18nPlugin)
 Vue.mixin(capacitor)
 
-const app = new Promise(() => {
+const app = () => {
   i18n.setLocales(navigator.languages)
-  await i18n.load()
-  
-  global['Floccus'] = new Vue({
-    el: '#app',
-    router,
-    store,
-    vuetify,
-    render: (h) => h(App),
+  i18n.load().then(() => {
+    window['floccus'] = global['Floccus'] = new Vue({
+      el: '#app',
+      router,
+      store,
+      vuetify,
+      render: (h) => h(App),
+    })
   })
-})
+}
 
 export default app

--- a/src/ui/index.js
+++ b/src/ui/index.js
@@ -10,15 +10,17 @@ import {i18n} from '../lib/native/I18n'
 Vue.mixin(i18nPlugin)
 Vue.mixin(capacitor)
 
-i18n.setLocales(navigator.languages)
-i18n.load()
-
-const app = (global['Floccus'] = new Vue({
-  el: '#app',
-  store,
-  router,
-  vuetify,
-  render: (h) => h(App),
-}))
+const app = new Promise(() => {
+  i18n.setLocales(navigator.languages)
+  await i18n.load()
+  
+  global['Floccus'] = new Vue({
+    el: '#app',
+    router,
+    store,
+    vuetify,
+    render: (h) => h(App),
+  })
+})
 
 export default app

--- a/src/ui/native.js
+++ b/src/ui/native.js
@@ -7,26 +7,21 @@ import store from './store/native'
 import i18nPlugin from './plugins/i18n'
 import { router } from './NativeRouter'
 import {i18n} from '../lib/native/I18n'
-import { Device } from '@capacitor/device'
 
 Vue.mixin(i18nPlugin)
 Vue.mixin(capacitor)
 
 const app = () => {
-  Device.getLanguageCode()
-    .then(({ value }) => {
-      i18n.setLocales([value])
-      return i18n.load()
+  i18n.setLocales(navigator.languages)
+  i18n.load().then(() => {
+    window['floccus'] = global['Floccus'] = new Vue({
+      el: '#app',
+      router,
+      store,
+      vuetify,
+      render: (h) => h(App),
     })
-    .then(() => {
-      window['floccus'] = global['Floccus'] = new Vue({
-        el: '#app',
-        router,
-        store,
-        vuetify,
-        render: (h) => h(App),
-      })
-    })
+  })
 }
 
 export default app

--- a/src/ui/native.js
+++ b/src/ui/native.js
@@ -12,18 +12,18 @@ import { Device } from '@capacitor/device'
 Vue.mixin(i18nPlugin)
 Vue.mixin(capacitor)
 
-const app = (global['Floccus'] = new Vue({
-  el: '#app',
-  router,
-  store,
-  vuetify,
-  render: (h) => h(App),
-}))
-
-Device.getLanguageCode()
+const app = Device.getLanguageCode()
   .then(({ value }) => {
     i18n.setLocales([value])
-    i18n.load()
-  })
+    await i18n.load()
+
+    global['Floccus'] = new Vue({
+      el: '#app',
+      router,
+      store,
+      vuetify,
+      render: (h) => h(App),
+    })
+})
 
 export default app

--- a/src/ui/native.js
+++ b/src/ui/native.js
@@ -12,18 +12,21 @@ import { Device } from '@capacitor/device'
 Vue.mixin(i18nPlugin)
 Vue.mixin(capacitor)
 
-const app = Device.getLanguageCode()
-  .then(({ value }) => {
-    i18n.setLocales([value])
-    await i18n.load()
-
-    global['Floccus'] = new Vue({
-      el: '#app',
-      router,
-      store,
-      vuetify,
-      render: (h) => h(App),
+const app = () => {
+  Device.getLanguageCode()
+    .then(({ value }) => {
+      i18n.setLocales([value])
+      return i18n.load()
     })
-})
+    .then(() => {
+      window['floccus'] = global['Floccus'] = new Vue({
+        el: '#app',
+        router,
+        store,
+        vuetify,
+        render: (h) => h(App),
+      })
+    })
+}
 
 export default app


### PR DESCRIPTION
- Fix loading languages with hyphens
- Fix async loding languages

I tested in chrome on windows system and the language loads correctly.
![image](https://user-images.githubusercontent.com/5285894/151629621-0d1e3fa5-e49b-4b90-b3c9-c5f4bc63cfdc.png)

But not tested on android because I won't package as apk.

I have doubts about whether the language will load correctly on Android.
Because the documentation of `@capacitor/device` describes that `getLanguageCode()` returns a value of `Two character language code.`, so `zh-CN` will return `zh`?
If so, that won't load Simplified Chinese correctly, because there is no `zh` in the translation, only `zh-CN` and `zh-TW`, and they won't be loaded.