### PR TITLE
L.175 : added Math.ceil

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -517,7 +517,7 @@
     "message": "Download anonymized logs"
   },
   "DescriptionDownloadlogs": {
-    "message": "Floccus logs all its actions in a log file that you can examine yourself or send to the developers for debugging purposes. When sending anonymized logs, make sure to still check the downloaded file for sensitive data that might not have been caught by the anonymization process."
+    "message": "Floccus logs all its actions in a log file that you can examine yourself or send to the developers for debugging purposes. This log file is also available in an anonymized version that hides the titles and links of your bookmarks. When sending anonymized logs, make sure to still check the downloaded file for sensitive data that might not have been caught by the anonymization process."
   },
   "ErrorFolderloopselected": {
     "message": "Cannot move a folder into itself"

--- a/src/lib/strategies/Default.ts
+++ b/src/lib/strategies/Default.ts
@@ -172,7 +172,7 @@ export default class SyncProcess {
     if (localCountTotal > 5 && localCountDeleted / localCountTotal > 0.5) {
       const failsafe = this.server.getData().failsafe
       if (failsafe !== false || typeof failsafe === 'undefined') {
-        throw new FailsafeError((localCountDeleted / localCountTotal) * 100)
+        throw new FailsafeError(Math.ceil((localCountDeleted / localCountTotal) * 100))
       }
     }
   }

--- a/src/ui/components/AccountCard.vue
+++ b/src/ui/components/AccountCard.vue
@@ -100,6 +100,12 @@
                   <v-icon>{{ item.icon }}</v-icon> {{ item.text }}
                 </template>
               </v-select>
+            </v-col>
+          </v-row>
+          <v-row
+            no-gutters
+            class="mt-1">
+            <v-col class="d-flex flex-row">
               <v-btn
                 v-if="!account.data.syncing"
                 class="primary"


### PR DESCRIPTION
Added Math.ceil to the line 175. To avoid decimal numbers and only allow integers.
"Ceil" because if its 50.00145 %, it'd be preferable to show 51%, as the failsafe rule in settings states that it will only trigger when "more" than 50% is removed.

Fixes #1167