### PR TITLE
Feat/replace merge icon

### DIFF
--- a/src/ui/components/AccountCard.vue
+++ b/src/ui/components/AccountCard.vue
@@ -84,6 +84,24 @@
             no-gutters
             class="mt-2">
             <v-col class="d-flex flex-row">
+              <v-btn
+                v-if="!account.data.syncing"
+                class="primary"
+                small
+                :title="t('LabelSyncnow')"
+                :aria-label="t('LabelSyncnow')"
+                @click="onTriggerSync">
+                <v-icon>mdi-sync</v-icon>
+              </v-btn>
+              <v-btn
+                v-else
+                small
+                :title="t('LabelCancelsync')"
+                :aria-label="t('LabelCancelsync')"
+                @click="onCancelSync">
+                <v-icon>mdi-cancel</v-icon>
+              </v-btn>
+              <v-spacer></v-spacer>
               <v-select
                 v-model="account.data.strategy"
                 dense
@@ -109,23 +127,6 @@
                   </v-list-item-title>
                 </template>
               </v-select>
-              <v-btn
-                v-if="!account.data.syncing"
-                class="primary"
-                small
-                :title="t('LabelSyncnow')"
-                :aria-label="t('LabelSyncnow')"
-                @click="onTriggerSync">
-                <v-icon>mdi-sync</v-icon>
-              </v-btn>
-              <v-btn
-                v-else
-                small
-                :title="t('LabelCancelsync')"
-                :aria-label="t('LabelCancelsync')"
-                @click="onCancelSync">
-                <v-icon>mdi-cancel</v-icon>
-              </v-btn>
             </v-col>
           </v-row>
           <v-row :class="{'d-none': !showDetails, 'pa-2': true, 'mt-3': true, 'justify-space-between': true}">

--- a/src/ui/components/AccountCard.vue
+++ b/src/ui/components/AccountCard.vue
@@ -218,7 +218,7 @@ export default {
       strategyIcons: {
         slave: 'mdi-arrow-down-bold',
         overwrite: 'mdi-arrow-up-bold',
-        default: 'mdi-sync',
+        default: 'mdi-call-merge',
       },
       strategyLabels: {
         slave: this.t('LabelSyncDown'),


### PR DESCRIPTION
Sync icon and merge icon are the same. To avoid confusion (even more if they are side by side), I propose to replace by an icon representing two arrows merging.
It fits nicely I think.