### PR TITLE
Replace merge icon to avoid confusion with sync icon

### DIFF
--- a/src/ui/components/AccountCard.vue
+++ b/src/ui/components/AccountCard.vue
@@ -217,7 +217,7 @@ export default {
       strategyIcons: {
         slave: 'mdi-arrow-down-bold',
         overwrite: 'mdi-arrow-up-bold',
-        default: 'mdi-call-merge',
+        default: 'mdi-merge',
       },
       strategyLabels: {
         slave: this.t('LabelSyncDown'),

--- a/src/ui/components/AccountCard.vue
+++ b/src/ui/components/AccountCard.vue
@@ -217,7 +217,7 @@ export default {
       strategyIcons: {
         slave: 'mdi-arrow-down-bold',
         overwrite: 'mdi-arrow-up-bold',
-        default: 'mdi-sync',
+        default: 'mdi-call-merge',
       },
       strategyLabels: {
         slave: this.t('LabelSyncDown'),


### PR DESCRIPTION
Sync icon and merge icon are the same. To avoid confusion, I propose to replace by an icon representing two arrows merging.