### PR TITLE
No cache for WebDAV downloadFile* functions

### DIFF
--- a/src/lib/adapters/WebDav.ts
+++ b/src/lib/adapters/WebDav.ts
@@ -371,6 +371,7 @@ export default class WebDavAdapter extends CachingAdapter {
         headers: {
           Authorization: 'Basic ' + authString
         },
+        cache: 'no-store',
         credentials: 'omit',
         ...(!this.server.allowRedirects && {redirect: 'manual'})
       })
@@ -403,7 +404,9 @@ export default class WebDavAdapter extends CachingAdapter {
         url: fullURL,
         method: 'GET',
         headers: {
-          Authorization: 'Basic ' + authString
+          Authorization: 'Basic ' + authString,
+          Pragma: 'no-cache',
+          'Cache-Control': 'no-cache'
         },
         responseType: 'text'
       })


### PR DESCRIPTION
This should fix #956, but haven't tested because I have nothing set up to do it.