### PR TITLE
Support Node v18 for build

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,27 +102,27 @@ Translations can now be provided over at [transifex](https://www.transifex.com/f
 #### Setting up a dev environment
 
 - Clone this repository.
-- Install node.js v16 and npm 8
-- In the root of your floccus repo, run `npm install && npm install -g gulp`
-- Run `gulp` to build
-- Find out more on how to develop browser extensions here: <https://extensionworkshop.com/>
+- Install the [latest LTS version of node.js](https://nodejs.org/en/download/).
+- In the root of your floccus repo, run `npm install`.
+- Run `npm run build` to build.
+- Find out more on how to develop browser extensions here: <https://extensionworkshop.com/>.
 
 For building the android app you'll need Android Studio
 
-- Open the android/ folder in Android studio and build the App like any other Android app.
-- `gulp` and `gulp watch` will push changes to android/ as necessary
+- Open the `android/` folder in Android studio and build the App like any other Android app.
+- `npm run build` and `npm run watch` will push changes to `android/` as necessary.
 
 #### Building
 
-- `gulp`
+- `npm run build`
 
 Run the following to automatically compile changes as you make them:
 
-- `gulp watch`
+- `npm run watch`
 
 #### Releasing
 
-- `gulp release`
+- `npm run build-release`
 
 ## Backers
 
@@ -147,5 +147,5 @@ Support this project by becoming a sponsor. Your logo will show up here with a l
 
 ## License
 
-(c) Marcel Klehr  
+(c) Marcel Klehr
 MPL-2.0 (see LICENSE.txt)

--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,6 @@
         "eslint-plugin-standard": "^4.1.0",
         "eslint-plugin-vue": "9.x.x",
         "execa": "^6.1.0",
-        "fibers": "^5.0.0",
         "file-loader": "^6.2.0",
         "gist-client": "^1.1.1",
         "gulp": "^4",
@@ -5250,6 +5249,8 @@
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "bin": {
         "detect-libc": "bin/detect-libc.js"
       },
@@ -6725,6 +6726,8 @@
       "integrity": "sha512-VMC7Frt87Oo0AOJ6EcPFbi+tZmkQ4tD85aatwyWL6I9cYMJmm2e+pXUJsfGZ36U7MffXtjou2XIiWJMtHriErw==",
       "dev": true,
       "hasInstallScript": true,
+      "optional": true,
+      "peer": true,
       "dependencies": {
         "detect-libc": "^1.0.3"
       },
@@ -19659,7 +19662,9 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha512-pGjwhsmsp4kL2RTz08wcOlGN83otlqHeD/Z5T8GXZB+/YcpQ/dgo+lbU8ZsGxV0HIvqqxo9l7mqYwyYMD9bKDg==",
-      "dev": true
+      "dev": true,
+      "optional": true,
+      "peer": true
     },
     "didyoumean": {
       "version": "1.2.2",
@@ -20821,6 +20826,8 @@
       "resolved": "https://registry.npmjs.org/fibers/-/fibers-5.0.1.tgz",
       "integrity": "sha512-VMC7Frt87Oo0AOJ6EcPFbi+tZmkQ4tD85aatwyWL6I9cYMJmm2e+pXUJsfGZ36U7MffXtjou2XIiWJMtHriErw==",
       "dev": true,
+      "optional": true,
+      "peer": true,
       "requires": {
         "detect-libc": "^1.0.3"
       }

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "build": "gulp",
     "build-release": "gulp release",
+    "watch": "gulp watch",
     "test": "node --unhandled-rejections=strict test/selenium-runner.js"
   },
   "repository": {
@@ -44,7 +45,6 @@
     "eslint-plugin-standard": "^4.1.0",
     "eslint-plugin-vue": "9.x.x",
     "execa": "^6.1.0",
-    "fibers": "^5.0.0",
     "file-loader": "^6.2.0",
     "gist-client": "^1.1.1",
     "gulp": "^4",

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -12,10 +12,10 @@ module.exports = {
     ),
     options: path.join(__dirname, 'src', 'entries', 'options.js'),
     test: path.join(__dirname, 'src', 'entries', 'test.js'),
-    native: path.join(__dirname, 'src', 'entries', 'native.js')
+    native: path.join(__dirname, 'src', 'entries', 'native.js'),
   },
   optimization: {
-    splitChunks: { chunks: 'async' }
+    splitChunks: { chunks: 'async' },
   },
   output: {
     path: path.resolve(__dirname, 'dist', 'js'),
@@ -45,7 +45,7 @@ module.exports = {
             options: {
               implementation: require('sass'),
               sassOptions: {
-                fiber: require('fibers'),
+                fiber: false,
                 indentedSyntax: true, // optional
               },
             },
@@ -73,7 +73,7 @@ module.exports = {
                 '@babel/preset-env',
                 {
                   useBuiltIns: 'usage',
-                  corejs: {version: '3.19', proposals: true},
+                  corejs: { version: '3.19', proposals: true },
                   shippedProposals: true,
                 },
               ],


### PR DESCRIPTION
closes #1284

Remove dependency "fibers", which does not work with node 16 and above - see https://github.com/laverdet/node-fibers#readme.

Disable use of "fibers" in "sass-loader" according to https://webpack.js.org/loaders/sass-loader/#string.

Update instructions to setup development environment in README. It should be possible to build the project with nodejs 18 (current LTS version) now.

I've tried `npm run build` and `npm run watch`, and both succeeded with out errors. I haven't tried actually running the project in Android Studio, for example.
