### PR TITLE
Improve error message: E035: Failed to create the following bookmark …

### DIFF
--- a/src/errors/Error.ts
+++ b/src/errors/Error.ts
@@ -294,7 +294,7 @@ export class FileUnreadableError extends FloccusError {
 export class CreateBookmarkError extends FloccusError {
   public bookmark: Bookmark
   constructor(bookmark: Bookmark) {
-    super(`E035: Failed to create the following bookmark on the server: ${bookmark}`)
+    super(`E035: Failed to create the following bookmark on the server: ${JSON.stringify(bookmark)}`)
     this.code = 35
     this.bookmark = bookmark
     Object.setPrototypeOf(this, CreateBookmarkError.prototype)


### PR DESCRIPTION
…on the server: [object Object]

If the sync fails due to wrongly escaped characters, you often get the error message: E035: Failed to create the following bookmark on the server: [object Object]

Stringify the bookmark object to help the user to guess which bookmark could cause the problem.
