### PR TITLE
Fix typo

### DIFF
--- a/src/lib/adapters/Git.ts
+++ b/src/lib/adapters/Git.ts
@@ -114,7 +114,7 @@ export default class GitAdapter extends CachingAdapter {
     } catch (e) {
       if (e && e.code === git.Errors.NotFoundError.code && (e.data.what === 'HEAD' || e.data.what === this.server.branch)) {
         Logger.log('(git) writeFile ' + this.dir + '/README.md')
-        await this.fs.promises.writeFile(this.dir + '/README.md', 'This repository is used to syncrhonize bookmarks via [floccus](https://floccus.org).', {mode: 0o777, encoding: 'utf8'})
+        await this.fs.promises.writeFile(this.dir + '/README.md', 'This repository is used to synchronize bookmarks via [floccus](https://floccus.org).', {mode: 0o777, encoding: 'utf8'})
         Logger.log('(git) add .')
         await git.add({fs: this.fs, dir: this.dir, filepath: '.'})
         Logger.log('(git) commit')
@@ -331,7 +331,7 @@ export default class GitAdapter extends CachingAdapter {
       remote: 'origin',
       force: true
     })
-    await fs.promises.writeFile(this.dir + '/README.md', 'This repository is used to syncrhonize bookmarks via [floccus](https://floccus.org).', {mode: 0o777, encoding: 'utf8'})
+    await fs.promises.writeFile(this.dir + '/README.md', 'This repository is used to synchronize bookmarks via [floccus](https://floccus.org).', {mode: 0o777, encoding: 'utf8'})
     await git.add({fs, dir: this.dir, filepath: '.'})
     await git.commit({
       fs,


### PR DESCRIPTION
This PR simply fixes 2 typos in the word "syncrhonize" written in the README file created for a new git repository.