### PR TITLE
test: Don't run an initial getBookmarks on each test

### DIFF
--- a/src/test/test.js
+++ b/src/test/test.js
@@ -284,9 +284,7 @@ describe('Floccus', function() {
             await account.delete()
           })
           it('should create local bookmarks on the server', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -328,9 +326,7 @@ describe('Floccus', function() {
             )
           })
           it('should create empty local folders on the server', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -366,10 +362,6 @@ describe('Floccus', function() {
             )
           })
           it('should create local javascript bookmarks on the server', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
-
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
               title: 'foo',
@@ -446,9 +438,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.noCache) {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -501,9 +491,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.noCache) {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -565,9 +553,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.noCache) {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -611,9 +597,7 @@ describe('Floccus', function() {
             )
           })
           it('should update the server on local folder moves', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -856,9 +840,7 @@ describe('Floccus', function() {
             )
           })
           it('should not delete additions while sync is running', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -915,9 +897,7 @@ describe('Floccus', function() {
             )
           })
           it('should be able to handle duplicates', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const bookmarkData = {
@@ -969,9 +949,7 @@ describe('Floccus', function() {
           })
           it('should deduplicate unnormalized URLs', async function() {
             const adapter = account.server
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             // create bookmark on server
             const serverTree = await getAllBookmarks(account)
@@ -1049,9 +1027,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.type === 'nextcloud-bookmarks' && (APP_VERSION !== 'stable' && APP_VERSION !== 'master' && APP_VERSION !== 'stable3')) {
               this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             // create bookmark locally
             const localRoot = account.getData().localRoot
@@ -1112,9 +1088,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.noCache) {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -1175,9 +1149,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.noCache) {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -1245,9 +1217,7 @@ describe('Floccus', function() {
             )
           })
           it('should handle strange characters well', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -1298,9 +1268,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.noCache) {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -1339,9 +1307,7 @@ describe('Floccus', function() {
               return this.skip()
             }
             const adapter = account.server
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -1419,9 +1385,7 @@ describe('Floccus', function() {
             }
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -1478,9 +1442,7 @@ describe('Floccus', function() {
           it('should move items successfully even into new folders', async function() {
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -1564,9 +1526,7 @@ describe('Floccus', function() {
           it('should move items successfully when mixing creation and moving (1)', async function() {
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -1673,9 +1633,7 @@ describe('Floccus', function() {
           it('should move items successfully when mixing creation and moving (2)', async function() {
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const aFolder = await browser.bookmarks.create({
               title: 'a',
@@ -1811,9 +1769,7 @@ describe('Floccus', function() {
             }
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const aFolder = await browser.bookmarks.create({
               title: 'a',
@@ -1889,9 +1845,7 @@ describe('Floccus', function() {
             const localRoot = account.getData().localRoot
 
             const adapter = account.server
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const aFolder = await browser.bookmarks.create({
               title: 'a',
@@ -2007,9 +1961,7 @@ describe('Floccus', function() {
               this.skip()
             }
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -2061,9 +2013,7 @@ describe('Floccus', function() {
             }
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -2152,9 +2102,7 @@ describe('Floccus', function() {
             }
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -2286,9 +2234,7 @@ describe('Floccus', function() {
             }
             const localRoot = account.getData().localRoot
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -2390,9 +2336,7 @@ describe('Floccus', function() {
             await account.setData({...account.getData(), localRoot: root.id})
             account = await Account.get(account.id)
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const barFolder = await browser.bookmarks.create({
               title: 'bar',
@@ -2439,9 +2383,7 @@ describe('Floccus', function() {
             account = await Account.get(account.id)
             const adapter = account.server
 
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             let bookmark
             let serverTree = await getAllBookmarks(account)
@@ -2502,9 +2444,7 @@ describe('Floccus', function() {
             if (ACCOUNT_DATA.type === 'linkwarden') {
               return this.skip()
             }
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const localRoot = account.getData().localRoot
             const fooFolder = await browser.bookmarks.create({
@@ -4855,9 +4795,7 @@ describe('Floccus', function() {
             await account.delete()
           })
           it('should create local tabs on the server', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             browser.tabs.create({
               index: 1,
@@ -4891,9 +4829,7 @@ describe('Floccus', function() {
             )
           })
           it('should create server bookmarks as tabs', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const adapter = account.server
             const serverTree = await getAllBookmarks(account)
@@ -4937,9 +4873,7 @@ describe('Floccus', function() {
             )
           })
           it('should update the server when pushing local changes', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             await account.setData({...account.getData(), strategy: 'overwrite'})
 
@@ -4999,9 +4933,7 @@ describe('Floccus', function() {
             )
           })
           it('should update local tabs when pulling server changes', async function() {
-            expect(
-              (await getAllBookmarks(account)).children
-            ).to.have.lengthOf(0)
+            
 
             const adapter = account.server
             const serverTree = await getAllBookmarks(account)


### PR DESCRIPTION
To avoid running first-run checks like the javascript feature detection