### PR TITLE
Catch and log any errors we encounter when parsing a URL to display its hostname

### DIFF
--- a/src/ui/views/native/Tree.vue
+++ b/src/ui/views/native/Tree.vue
@@ -436,7 +436,12 @@ export default {
   components: { DialogImportBookmarks, FaviconImage, DialogEditBookmark, DialogEditFolder, Drawer },
   filters: {
     hostname(url) {
-      return new URL(url).hostname
+      try {
+        return new URL(url).hostname
+      } catch (e) {
+        console.error(`${e}: ${url}`)
+        return '(bad url)'
+      }
     }
   },
   data() {


### PR DESCRIPTION
This is a part of https://github.com/floccusaddon/floccus/issues/1826 - avoid the app crashing when we find an invalid URL has made its way into the list.