### PR TITLE
Check that a URL is valid as soon as we load the Add Bookmark dialog

### DIFF
--- a/src/ui/views/native/AddBookmarkIntent.vue
+++ b/src/ui/views/native/AddBookmarkIntent.vue
@@ -103,7 +103,7 @@ export default {
   data() {
     return {
       url: this.$route.params.url,
-      urlError: null,
+      urlError: this.checkUrl(this.$route.params.url),
       title: this.$route.params.title || '',
       temporaryParent: null,
       displayFolderChooser: false,
@@ -151,13 +151,7 @@ export default {
       this.$store.dispatch(actions.LOAD_TREE, this.id)
     },
     url() {
-      this.urlError = null
-      try {
-        // eslint-disable-next-line
-        new URL(this.url)
-      } catch (e) {
-        this.urlError = 'Invalid URL'
-      }
+      this.urlError = this.checkUrl(this.url)
     },
     tree() {
       const parentFolder = this.tree.findFolder(this.$store.state.lastFolders[this.id]) || this.tree.findFolder(this.tree.id)
@@ -189,6 +183,15 @@ export default {
     },
     onTriggerFolderChooser() {
       this.displayFolderChooser = true
+    },
+    checkUrl(url) {
+      try {
+        // eslint-disable-next-line
+        new URL(url)
+        return null
+      } catch (e) {
+        return 'Invalid URL'
+      }
     }
   }
 }


### PR DESCRIPTION
This is a part of addressing https://github.com/floccusaddon/floccus/issues/1826 - make sure that we display an error message in the Add Bookmark dialog immediately, if the shared URL is bad.

Before this change, there would be no error message in the "Add Bookmark" screen until we edited the URL, but now the error appears immediately:

![image](https://github.com/user-attachments/assets/d3b59a70-3d02-4318-b6da-2c975513769f)

I have zero Vue experience, so please let me know if I did it wrong.