### PR TITLE
Prevent saving a newly-added bookmark if the URL is bad

### DIFF
--- a/src/ui/views/native/AddBookmarkIntent.vue
+++ b/src/ui/views/native/AddBookmarkIntent.vue
@@ -177,7 +177,7 @@ export default {
   },
   methods: {
     async onSave() {
-      if (!this.tree.findFolder(this.temporaryParent)) {
+      if (!this.tree.findFolder(this.temporaryParent) || this.urlError) {
         return
       }
       await this.$store.dispatch(actions.CREATE_BOOKMARK, {


### PR DESCRIPTION
This is another part of https://github.com/floccusaddon/floccus/issues/1826 . Just like in the Edit dialog, avoid saving a newly-shared bookmark if its URL is invalid.