### PR TITLE
Try to find a valid URL when an app shares title+URL stuffed together

### DIFF
--- a/src/ui/views/native/Home.vue
+++ b/src/ui/views/native/Home.vue
@@ -64,7 +64,7 @@ export default {
           title = ''
         })
       } else {
-        url = result.url
+        url = this.findUrl(result.url)
         title = ''
       }
 
@@ -95,6 +95,32 @@ export default {
         }
       })
       return true
+    },
+    /**
+     * Check that the supplied string is a valid URL. If not, look for a
+     * URL at the end of the string, to match the input we see from the
+     * Share action in some apps.
+     */
+    findUrl(url) {
+      try {
+        // If we can parse this string as a URL, we are done.
+        // eslint-disable-next-line no-new
+        new URL(url)
+        return url
+      } catch (e1) {
+        // If not, see whether we can find a URL at the end of this string.
+        // This happens when we share from the Amazon Shopping app.
+        const lastWord = url.trim().split(' ').slice(-1)[0]
+        try {
+          // eslint-disable-next-line no-new
+          new URL(lastWord)
+          // The last word is a URL - return it
+          return lastWord
+        } catch (e2) {
+          // We didn't find a valid URL - return our input unchanged
+          return url
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
Fixes #1826 .

Look for a URL at the end of a long string of title+URL passed to us from `SendIntent`. It's possible a better fix might be available by modifying `SendIntent` (or even by asking for a fix to the Amazon Shopping app?) but this makes things work as they should, and doesn't do anything if we are given a valid URL, so hopefully can't do much harm even if this is later fixed upstream.

Before:

![amazon-share-before](https://github.com/user-attachments/assets/18ae7738-0a70-4e79-9fa7-0413dc81c99c)

After:

![amazon-share-after](https://github.com/user-attachments/assets/80a87318-44ec-4ba4-ae72-f11f78abd8d0)
