### PR TITLE
script to override manifest.json for Firefox and prevent accidental GIT commits

### DIFF
--- a/manifest-firefox-override.sh
+++ b/manifest-firefox-override.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/sh
+
+# Local development workaround for Firefox.
+#
+# Once you build this extension (with `npm install` and `npm run build`, as per <README.md>), to
+# load it, visit Firefox special URL about:debugging#/runtime/this-firefox. Click button "Load
+# Temporary Add-on..." That button shows a file/folder picker.
+#
+# Problem: The file picker does allow you to select `manifest.firefox.json`, BUT it will not load
+# it. It loads `manifest.json` (from the directory where you selected `manifest.firefox.json`)
+# instead. (Indeed, a Firefox defect - but life is too short for us to waste it on Mozilla's
+# bugzilla....)
+#
+# Firefox doesn't allow to use symlinks to workaround the above problem (see
+# https://bugzilla.mozilla.org/show_bug.cgi?id=803999 - symlinks are a security problem).
+#
+# Workaround: This script
+# 1. copies manifest.firefox.json over manifest.json
+# 2. prevents that change from being accidentally committed to GIT.
+
+# Enter the directory where this script is (in case we call it from somewhere else).
+cd "${0%/*}"
+
+# Invoking `/usr/bin/cp` directly, in case there's an alias that warns about overriding existing
+# files.
+/usr/bin/cp manifest.firefox.json manifest.json
+
+# See also
+# https://stackoverflow.com/questions/13630849/git-difference-between-assume-unchanged-and-skip-worktree
+git update-index --skip-worktree manifest.json


### PR DESCRIPTION
Thank you for Floccus. Hoping to contribute more.

You as an author of Floccus may have some more advanced setup that avoids the below problem, but for most developers (even ones with experience of developing Firefox extensions), the problem described below is a big time waster/accident maker. Hoping the workaround script is clear.

If you know of any more mistake/me-the-local-idiot-proof setup with less work or more reproducible/automated, I'm open to alternatives.

(Also in `manifest-firefox-override.sh`:)

Local development workaround for Firefox.

Once you build this extension (with `npm install` and `npm run build`, as per <README.md>), to load it, visit Firefox special URL about:debugging#/runtime/this-firefox. Click button "Load Temporary Add-on..." That button shows a file/folder picker.

Problem: The file picker does allow you to select `manifest.firefox.json`, BUT it will not load it. It loads `manifest.json` (from the directory where you selected `manifest.firefox.json`) instead. (Indeed, a Firefox defect - but life is too short for us to waste it on Mozilla's bugzilla....)

Firefox doesn't allow to use symlinks to workaround the above problem (see https://bugzilla.mozilla.org/show_bug.cgi?id=803999 - symlinks are a security problem).

Workaround: This script
1. copies manifest.firefox.json over manifest.json
2. prevents that change from being accidentally committed to GIT.
