### PR TITLE
Fix: Use the new `/api/v1/search` route for fetching the links

### DIFF
--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -195,7 +195,7 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     do {
       ({ data } = await this.sendRequest('GET', `/api/v1/search?cursor=${links.length ? links[links.length - 1].id : ''}`))
       links.push(...data.links)
-    } while (response.length !== 0)
+    } while (data.length !== 0)
 
     const { response: collections } = await this.sendRequest('GET', `/api/v1/collections`)
 

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -191,7 +191,7 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
 
   async getBookmarksTree(loadAll?: boolean): Promise<Folder<typeof ItemLocation.SERVER>> {
     const links = []
-    let response
+    let data
     do {
       ({ data } = await this.sendRequest('GET', `/api/v1/search?cursor=${links.length ? links[links.length - 1].id : ''}`))
       links.push(...data.links)

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -193,9 +193,9 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     const links = []
     let data
     do {
-      ({ data } = await this.sendRequest('GET', `/api/v1/search?cursor=${links.length ? links[links.length - 1].id : ''}`))
+      ({ data } = await this.sendRequest('GET', `/api/v1/search?searchQueryString=&cursor=${data?.nextCursor || : ''}`))
       links.push(...data.links)
-    } while (data.length !== 0)
+    } while (data.links.length !== 0)
 
     const { response: collections } = await this.sendRequest('GET', `/api/v1/collections`)
 

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -193,7 +193,7 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     const links = []
     let data
     do {
-      ({ data } = await this.sendRequest('GET', `/api/v1/search?searchQueryString=&cursor=${data?.nextCursor || : ''}`))
+      ({ data } = await this.sendRequest('GET', `/api/v1/search?searchQueryString=&cursor=${data?.nextCursor ||''}`))
       links.push(...data.links)
     } while (data.links.length !== 0)
 

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -193,8 +193,8 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     const links = []
     let response
     do {
-      ({ response } = await this.sendRequest('GET', `/api/v1/links?cursor=${links.length ? links[links.length - 1].id : ''}`))
-      links.push(...response)
+      ({ data } = await this.sendRequest('GET', `/api/v1/links?cursor=${links.length ? links[links.length - 1].id : ''}`))
+      links.push(...data.links)
     } while (response.length !== 0)
 
     const { response: collections } = await this.sendRequest('GET', `/api/v1/collections`)

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -193,7 +193,7 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     const links = []
     let response
     do {
-      ({ data } = await this.sendRequest('GET', `/api/v1/links?cursor=${links.length ? links[links.length - 1].id : ''}`))
+      ({ data } = await this.sendRequest('GET', `/api/v1/search?cursor=${links.length ? links[links.length - 1].id : ''}`))
       links.push(...data.links)
     } while (response.length !== 0)
 


### PR DESCRIPTION
Closes #2011.