### PR TITLE
feat: Optionally use murmurhash3 instead of sha256

### DIFF
--- a/src/lib/CachingTreeWrapper.ts
+++ b/src/lib/CachingTreeWrapper.ts
@@ -1,4 +1,4 @@
-import { CachingResource, OrderFolderResource } from './interfaces/Resource'
+import { CachingResource, ICapabilities, IHashSettings, OrderFolderResource } from './interfaces/Resource'
 import { Bookmark, Folder, ItemLocation } from './Tree'
 import CacheTree from './CacheTree'
 import Ordering from './interfaces/Ordering'
@@ -73,5 +73,13 @@ export default class CachingTreeWrapper implements OrderFolderResource<typeof It
 
   getCacheTree(): Promise<Folder<typeof ItemLocation.LOCAL>> {
     return this.cacheTree.getBookmarksTree()
+  }
+
+  getCapabilities(): Promise<ICapabilities> {
+    return this.innerTree.getCapabilities()
+  }
+
+  setHashSettings(hashSettings: IHashSettings): void {
+    this.innerTree.setHashSettings(hashSettings)
   }
 }

--- a/src/lib/Crypto.ts
+++ b/src/lib/Crypto.ts
@@ -1,8 +1,16 @@
 import { fromUint8Array, toUint8Array } from 'js-base64'
+import { murmurhash3_32_gc } from './murmurhash3'
 
 export default class Crypto {
   static iterations = 250000
   static ivLength = 16
+
+  static async murmurHash3(message: string): Promise<string> {
+    const buf32 = new Uint32Array([murmurhash3_32_gc(message, 0)])
+    const buf8 = new Uint8Array(buf32.buffer)
+    buf8.reverse()
+    return this.bufferToHexstr(buf8)
+  }
 
   static async sha256(message: string): Promise<string> {
     const msgBuffer = new TextEncoder().encode(message) // encode as UTF-8

--- a/src/lib/LocalTabs.ts
+++ b/src/lib/LocalTabs.ts
@@ -1,6 +1,6 @@
 import browser from './browser-api'
 import Logger from './Logger'
-import { OrderFolderResource } from './interfaces/Resource'
+import { ICapabilities, IHashSettings, OrderFolderResource } from './interfaces/Resource'
 import PQueue from 'p-queue'
 import { Bookmark, Folder, ItemLocation } from './Tree'
 import Ordering from './interfaces/Ordering'
@@ -501,6 +501,18 @@ export default class LocalTabs implements OrderFolderResource<typeof ItemLocatio
 
   async isUsingBrowserTabs() {
     return true
+  }
+
+  async getCapabilities(): Promise<ICapabilities> {
+    return {
+      preserveOrder: true,
+      hashFn: ['murmur3', 'sha256']
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setHashSettings(hashSettings: IHashSettings): void {
+    // noop
   }
 }
 

--- a/src/lib/Tree.ts
+++ b/src/lib/Tree.ts
@@ -313,7 +313,7 @@ export class Folder<L extends TItemLocation> {
     return 0
   }
 
-  async hash({preserveOrder = false, hashFn = 'sha256'}: IHashSettings): Promise<string> {
+  async hash({preserveOrder = false, hashFn = 'sha256'}: IHashSettings = {preserveOrder: false, hashFn: 'sha256'}): Promise<string> {
     const cacheKey = `${preserveOrder}-${hashFn}`
     if (this.hashValue && typeof this.hashValue[cacheKey] !== 'undefined') {
       return this.hashValue[cacheKey]

--- a/src/lib/Tree.ts
+++ b/src/lib/Tree.ts
@@ -78,6 +78,12 @@ export class Bookmark<L extends TItemLocation> {
     return 0
   }
 
+  setHashCacheValue(hashSettings: IHashSettings, value: string): void {
+    const cacheKey = `${hashSettings.preserveOrder}-${hashSettings.hashFn}`
+    if (!this.hashValue) this.hashValue = {}
+    this.hashValue[cacheKey] = value
+  }
+
   async hash({preserveOrder = false, hashFn = 'sha256'}):Promise<string> {
     if (!this.hashValue) {
       this.hashValue = {}
@@ -311,6 +317,12 @@ export class Folder<L extends TItemLocation> {
       ) / Math.max(this.children.length, otherItem.children.length)
     }
     return 0
+  }
+
+  setHashCacheValue(hashSettings: IHashSettings, value: string): void {
+    const cacheKey = `${hashSettings.preserveOrder}-${hashSettings.hashFn}`
+    if (!this.hashValue) this.hashValue = {}
+    this.hashValue[cacheKey] = value
   }
 
   async hash({preserveOrder = false, hashFn = 'sha256'}: IHashSettings = {preserveOrder: false, hashFn: 'sha256'}): Promise<string> {

--- a/src/lib/Tree.ts
+++ b/src/lib/Tree.ts
@@ -1,6 +1,6 @@
 import Crypto from './Crypto'
 import Logger from './Logger'
-import TResource from './interfaces/Resource'
+import TResource, { IHashSettings } from './interfaces/Resource'
 import * as Parallel from 'async-parallel'
 
 const STRANGE_PROTOCOLS = ['data:', 'javascript:', 'about:', 'chrome:', 'file:']
@@ -37,7 +37,7 @@ export class Bookmark<L extends TItemLocation> {
   public tags: string[]
   public location: L
   public isRoot = false
-  private hashValue: string
+  private hashValue: Record<string, string>
 
   constructor({ id, parentId, url, title, tags, location }: { id:string|number, parentId:string|number, url:string, title:string, tags?: string[], location: L }) {
     this.id = id
@@ -78,13 +78,19 @@ export class Bookmark<L extends TItemLocation> {
     return 0
   }
 
-  async hash():Promise<string> {
+  async hash({preserveOrder = false, hashFn = 'sha256'}):Promise<string> {
     if (!this.hashValue) {
-      this.hashValue = await Crypto.sha256(
-        JSON.stringify({ title: this.title, url: this.url })
-      )
+      this.hashValue = {}
+      const json = JSON.stringify({ title: this.title, url: this.url })
+      if (hashFn === 'sha256') {
+        this.hashValue[hashFn] = await Crypto.sha256(json)
+      } else if (hashFn === 'murmur3') {
+        this.hashValue[hashFn] = await Crypto.murmurHash3(json)
+      } else {
+        throw new Error('Unsupported hash function specified')
+      }
     }
-    return this.hashValue
+    return this.hashValue[hashFn]
   }
 
   clone(withHash?: boolean):Bookmark<L> {
@@ -119,6 +125,7 @@ export class Bookmark<L extends TItemLocation> {
   toJSON() {
     // Flatten inherited properties for serialization
     const result = {}
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
     let obj = this
     while (obj) {
       Object.entries(obj).forEach(([key, value]) => {
@@ -306,9 +313,10 @@ export class Folder<L extends TItemLocation> {
     return 0
   }
 
-  async hash(preserveOrder = false): Promise<string> {
-    if (this.hashValue && typeof this.hashValue[String(preserveOrder)] !== 'undefined') {
-      return this.hashValue[String(preserveOrder)]
+  async hash({preserveOrder = false, hashFn = 'sha256'}: IHashSettings): Promise<string> {
+    const cacheKey = `${preserveOrder}-${hashFn}`
+    if (this.hashValue && typeof this.hashValue[cacheKey] !== 'undefined') {
+      return this.hashValue[cacheKey]
     }
 
     if (!this.loaded) {
@@ -329,17 +337,22 @@ export class Folder<L extends TItemLocation> {
       })
     }
     if (!this.hashValue) this.hashValue = {}
-    this.hashValue[String(preserveOrder)] = await Crypto.sha256(
-      JSON.stringify({
-        title: this.title,
-        children: await Parallel.map(
-          children,
-          child => child.hash(preserveOrder),
-          1
-        )
-      })
-    )
-    return this.hashValue[String(preserveOrder)]
+    const json = JSON.stringify({
+      title: this.title,
+      children: await Parallel.map(
+        children,
+        child => child.hash({preserveOrder, hashFn}),
+        1
+      )
+    })
+    if (hashFn === 'sha256') {
+      this.hashValue[cacheKey] = await Crypto.sha256(json)
+    } else if (hashFn === 'murmur3') {
+      this.hashValue[cacheKey] = await Crypto.murmurHash3(json)
+    } else {
+      throw new Error('Unsupported hash function specified')
+    }
+    return this.hashValue[cacheKey]
   }
 
   copy(withHash?:boolean):Folder<L> {

--- a/src/lib/adapters/Caching.ts
+++ b/src/lib/adapters/Caching.ts
@@ -12,13 +12,14 @@ import {
   UnknownMoveOriginError,
   UnknownMoveTargetError
 } from '../../errors/Error'
-import { BulkImportResource } from '../interfaces/Resource'
+import { BulkImportResource, ICapabilities, IHashSettings } from '../interfaces/Resource'
 
 export default class CachingAdapter implements Adapter, BulkImportResource<TItemLocation> {
   protected highestId: number
   public bookmarksCache: Folder<TItemLocation>
   protected server: any
   protected location: TItemLocation = ItemLocation.SERVER
+  protected hashSettings: IHashSettings
 
   constructor(server: any) {
     this.resetCache()
@@ -244,5 +245,16 @@ export default class CachingAdapter implements Adapter, BulkImportResource<TItem
 
   isAvailable(): Promise<boolean> {
     return Promise.resolve(true)
+  }
+
+  async getCapabilities(): Promise<ICapabilities> {
+    return {
+      preserveOrder: true,
+      hashFn: ['murmur3', 'sha256'],
+    }
+  }
+
+  setHashSettings(hashSettings: IHashSettings): void {
+    this.hashSettings = hashSettings
   }
 }

--- a/src/lib/adapters/Git.ts
+++ b/src/lib/adapters/Git.ts
@@ -170,7 +170,7 @@ export default class GitAdapter extends CachingAdapter {
 
     const status = await this.pullFromServer()
 
-    this.initialTreeHash = await this.bookmarksCache.hash(true)
+    this.initialTreeHash = await this.bookmarksCache.hash(this.hashSettings)
 
     Logger.log('onSyncStart: completed')
 
@@ -189,7 +189,7 @@ export default class GitAdapter extends CachingAdapter {
     clearInterval(this.lockingInterval)
 
     this.bookmarksCache = this.bookmarksCache.clone(false)
-    const newTreeHash = await this.bookmarksCache.hash(true)
+    const newTreeHash = await this.bookmarksCache.hash(this.hashSettings)
     if (newTreeHash !== this.initialTreeHash) {
       const fileContents = this.server.bookmark_file_type === 'xbel' ? createXBEL(this.bookmarksCache, this.highestId) : createHTML(this.bookmarksCache, this.highestId)
       Logger.log('(git) writeFile ' + this.dir + '/' + this.server.bookmark_file)

--- a/src/lib/adapters/GoogleDrive.ts
+++ b/src/lib/adapters/GoogleDrive.ts
@@ -298,7 +298,7 @@ export default class GoogleDriveAdapter extends CachingAdapter {
       this.alwaysUpload = true
     }
 
-    this.initialTreeHash = await this.bookmarksCache.hash(true)
+    this.initialTreeHash = await this.bookmarksCache.hash(this.hashSettings)
 
     Logger.log('onSyncStart: completed')
 
@@ -335,7 +335,7 @@ export default class GoogleDriveAdapter extends CachingAdapter {
     clearInterval(this.lockingInterval)
 
     this.bookmarksCache = this.bookmarksCache.clone(false)
-    const newTreeHash = await this.bookmarksCache.hash(true)
+    const newTreeHash = await this.bookmarksCache.hash(this.hashSettings)
 
     if (!this.fileId) {
       await this.createFile(await this.getXBELContent())

--- a/src/lib/adapters/Karakeep.ts
+++ b/src/lib/adapters/Karakeep.ts
@@ -1,7 +1,7 @@
 import Adapter from '../interfaces/Adapter'
 import { Bookmark, Folder, ItemLocation } from '../Tree'
 import PQueue from 'p-queue'
-import { IResource } from '../interfaces/Resource'
+import { ICapabilities, IHashSettings, IResource } from '../interfaces/Resource'
 import Logger from '../Logger'
 import {
   AuthenticationError,
@@ -564,5 +564,17 @@ export default class KarakeepAdapter implements Adapter, IResource<typeof ItemLo
     const json = res.data
 
     return json
+  }
+
+  async getCapabilities(): Promise<ICapabilities> {
+    return {
+      preserveOrder: false,
+      hashFn: ['murmur3', 'sha256'],
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setHashSettings(hashSettings: IHashSettings): void {
+    // noop
   }
 }

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -1,7 +1,7 @@
 import Adapter from '../interfaces/Adapter'
 import { Bookmark, Folder, ItemLocation } from '../Tree'
 import PQueue from 'p-queue'
-import { IResource } from '../interfaces/Resource'
+import { ICapabilities, IHashSettings, IResource } from '../interfaces/Resource'
 import Logger from '../Logger'
 import {
   AuthenticationError,
@@ -366,5 +366,17 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     const json = res.data
 
     return json
+  }
+
+  async getCapabilities(): Promise<ICapabilities> {
+    return {
+      preserveOrder: false,
+      hashFn: ['murmur3', 'sha256'],
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setHashSettings(hashSettings: IHashSettings): void {
+    // noop
   }
 }

--- a/src/lib/adapters/NextcloudBookmarks.ts
+++ b/src/lib/adapters/NextcloudBookmarks.ts
@@ -1,5 +1,4 @@
 // Nextcloud ADAPTER
-// All owncloud specifc stuff goes in here
 import { Capacitor, CapacitorHttp as Http } from '@capacitor/core'
 import Adapter from '../interfaces/Adapter'
 import HtmlSerializer from '../serializers/Html'
@@ -12,7 +11,7 @@ import PQueue from 'p-queue'
 import flatten from 'lodash/flatten'
 import {
   BulkImportResource,
-  ClickCountResource,
+  ClickCountResource, ICapabilities, IHashSettings,
   LoadFolderChildrenResource,
   OrderFolderResource
 } from '../interfaces/Resource'
@@ -78,6 +77,7 @@ export default class NextcloudBookmarksAdapter implements Adapter, BulkImportRes
   private ended = false
   private locked = false
   private hasFeatureJavascriptLinks: boolean = null
+  private hashSettings: IHashSettings
 
   constructor(server: NextcloudBookmarksConfig) {
     this.server = server
@@ -316,6 +316,9 @@ export default class NextcloudBookmarksAdapter implements Adapter, BulkImportRes
   }
 
   async _getFolderHash(folderId:string|number):Promise<string> {
+    if (this.hashSettings.hashFn !== 'sha256') {
+      throw new Error('Unsupported hash function: ' + this.hashSettings.hashFn + ' - Nextcloud Bookmarks only supports sha256')
+    }
     return this.sendRequest(
       'GET',
       `index.php/apps/bookmarks/public/rest/v2/folder/${folderId}/hash`
@@ -977,6 +980,13 @@ export default class NextcloudBookmarksAdapter implements Adapter, BulkImportRes
     return Promise.resolve(true)
   }
 
+  async getCapabilities(): Promise<ICapabilities> {
+    return {
+      preserveOrder: true,
+      hashFn: ['sha256'],
+    }
+  }
+
   async countClick(url: string): Promise<void> {
     try {
       await this.sendRequest(
@@ -990,5 +1000,9 @@ export default class NextcloudBookmarksAdapter implements Adapter, BulkImportRes
     } catch (e) {
       console.warn(e)
     }
+  }
+
+  setHashSettings(hashSettings: IHashSettings): void {
+    this.hashSettings = hashSettings
   }
 }

--- a/src/lib/adapters/NextcloudBookmarks.ts
+++ b/src/lib/adapters/NextcloudBookmarks.ts
@@ -310,7 +310,8 @@ export default class NextcloudBookmarksAdapter implements Adapter, BulkImportRes
 
     this.list = null
     tree.loaded = false
-    tree.hashValue = { true: await this._getFolderHash(tree.id) }
+    const treeHash = await this._getFolderHash(tree.id)
+    tree.setHashCacheValue(this.hashSettings, treeHash)
     this.tree = tree.copy(true) // we clone (withHash), so we can mess with our own version
     return tree
   }
@@ -386,7 +387,7 @@ export default class NextcloudBookmarksAdapter implements Adapter, BulkImportRes
           }
           if (!child.loaded) {
             const folderHash = await this._getFolderHash(child.id)
-            child.hashValue = { true: folderHash }
+            child.setHashCacheValue(this.hashSettings, folderHash)
           }
           await recurse(child.children)
         }, 5)

--- a/src/lib/adapters/WebDav.ts
+++ b/src/lib/adapters/WebDav.ts
@@ -324,7 +324,7 @@ export default class WebDavAdapter extends CachingAdapter {
       }
     }
 
-    this.initialTreeHash = await this.bookmarksCache.hash(true)
+    this.initialTreeHash = await this.bookmarksCache.hash(this.hashSettings)
 
     Logger.log('onSyncStart: completed')
 
@@ -354,7 +354,7 @@ export default class WebDavAdapter extends CachingAdapter {
     clearInterval(this.lockingInterval)
 
     this.bookmarksCache = this.bookmarksCache.clone(false)
-    const newTreeHash = await this.bookmarksCache.hash(true)
+    const newTreeHash = await this.bookmarksCache.hash(this.hashSettings)
     if (newTreeHash !== this.initialTreeHash) {
       const fullUrl = this.getBookmarkURL()
       let xbel = this.server.bookmark_file_type === 'xbel' ? createXBEL(this.bookmarksCache, this.highestId) : createHTML(this.bookmarksCache, this.highestId)

--- a/src/lib/browser/BrowserTree.ts
+++ b/src/lib/browser/BrowserTree.ts
@@ -1,7 +1,7 @@
 import browser from '../browser-api'
 import Logger from '../Logger'
 import * as Tree from '../Tree'
-import { IResource } from '../interfaces/Resource'
+import { ICapabilities, IHashSettings, IResource } from '../interfaces/Resource'
 import PQueue from 'p-queue'
 import Account from '../Account'
 import { Bookmark, Folder, ItemLocation, ItemType } from '../Tree'
@@ -48,7 +48,6 @@ export default class BrowserTree implements IResource<typeof ItemLocation.LOCAL>
     const allAccounts = await (await Account.getAccountClass()).getAllAccounts()
 
     const recurse = (node, parentId?, isOnToolbar?, rng?) => {
-
       if (
         allAccounts.some(
           acc => acc.getData().localRoot === node.id && String(node.id) !== String(this.rootId) && !acc.getData().nestedSync
@@ -393,5 +392,17 @@ export default class BrowserTree implements IResource<typeof ItemLocation.LOCAL>
 
   isAvailable(): Promise<boolean> {
     return Promise.resolve(true)
+  }
+
+  async getCapabilities(): Promise<ICapabilities> {
+    return {
+      preserveOrder: true,
+      hashFn: ['murmur3', 'sha256']
+    }
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  setHashSettings(hashSettings: IHashSettings): void {
+    // noop
   }
 }

--- a/src/lib/interfaces/Resource.ts
+++ b/src/lib/interfaces/Resource.ts
@@ -1,7 +1,20 @@
 import { Bookmark, Folder, ItemLocation, TItem, TItemLocation } from '../Tree'
 import Ordering from './Ordering'
 
+export type THashFunction = 'sha256' | 'murmur3'
+
+export interface ICapabilities {
+  preserveOrder: boolean,
+  hashFn: THashFunction[],
+}
+
+export interface IHashSettings {
+  preserveOrder: boolean,
+  hashFn: THashFunction,
+}
+
 export interface IResource<L extends TItemLocation> {
+  setHashSettings(hashSettings: IHashSettings):void
   getBookmarksTree(loadAll?: boolean):Promise<Folder<L>>
   createBookmark(bookmark: Bookmark<L>):Promise<string|number>
   updateBookmark(bookmark: Bookmark<L>):Promise<void>
@@ -11,6 +24,7 @@ export interface IResource<L extends TItemLocation> {
   updateFolder(folder:Folder<L>):Promise<void>
   removeFolder(folder:Folder<L>):Promise<void>
   isAvailable():Promise<boolean>
+  getCapabilities():Promise<ICapabilities>
   isUsingBrowserTabs?: () => Promise<boolean>
 }
 

--- a/src/lib/murmurhash3.js
+++ b/src/lib/murmurhash3.js
@@ -1,0 +1,66 @@
+/**
+ * JS Implementation of MurmurHash3 (r136) (as of May 20, 2011)
+ *
+ * @author <a href="mailto:gary.court@gmail.com">Gary Court</a>
+ * @see http://github.com/garycourt/murmurhash-js
+ * @author <a href="mailto:aappleby@gmail.com">Austin Appleby</a>
+ * @see http://sites.google.com/site/murmurhash/
+ *
+ * @param {string} key ASCII only
+ * @param {number} seed Positive integer only
+ * @return {number} 32-bit positive integer hash
+ */
+
+export function murmurhash3_32_gc(key, seed) {
+  var remainder, bytes, h1, h1b, c1, c2, k1, i
+
+  remainder = key.length & 3 // key.length % 4
+  bytes = key.length - remainder
+  h1 = seed
+  c1 = 0xcc9e2d51
+  c2 = 0x1b873593
+  i = 0
+
+  while (i < bytes) {
+    k1 =
+      ((key.charCodeAt(i) & 0xff)) |
+      ((key.charCodeAt(++i) & 0xff) << 8) |
+      ((key.charCodeAt(++i) & 0xff) << 16) |
+      ((key.charCodeAt(++i) & 0xff) << 24)
+    ++i
+
+    k1 = ((((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16))) & 0xffffffff
+    k1 = (k1 << 15) | (k1 >>> 17)
+    k1 = ((((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16))) & 0xffffffff
+
+    h1 ^= k1
+    h1 = (h1 << 13) | (h1 >>> 19)
+    h1b = ((((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16))) & 0xffffffff
+    h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16))
+  }
+
+  k1 = 0
+
+  switch (remainder) {
+    case 3: k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16
+    // eslint-disable-next-line no-fallthrough
+    case 2: k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8
+    // eslint-disable-next-line no-fallthrough
+    case 1: k1 ^= (key.charCodeAt(i) & 0xff)
+
+      k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff
+      k1 = (k1 << 15) | (k1 >>> 17)
+      k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff
+      h1 ^= k1
+  }
+
+  h1 ^= key.length
+
+  h1 ^= h1 >>> 16
+  h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff
+  h1 ^= h1 >>> 13
+  h1 = ((((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16))) & 0xffffffff
+  h1 ^= h1 >>> 16
+
+  return h1 >>> 0
+}

--- a/src/lib/native/NativeTree.ts
+++ b/src/lib/native/NativeTree.ts
@@ -22,9 +22,9 @@ export default class NativeTree extends CachingAdapter implements BulkImportReso
     const {value: tree} = await Storage.get({key: `bookmarks[${this.accountId}].tree`})
     const {value: highestId} = await Storage.get({key: `bookmarks[${this.accountId}].highestId`})
     if (tree) {
-      const oldHash = this.bookmarksCache && await this.bookmarksCache.cloneWithLocation(false, this.location).hash(true)
+      const oldHash = this.bookmarksCache && await this.bookmarksCache.cloneWithLocation(false, this.location).hash(this.hashSettings)
       this.bookmarksCache = Folder.hydrate(JSON.parse(tree)).copy(false)
-      const newHash = await this.bookmarksCache.hash(true)
+      const newHash = await this.bookmarksCache.hash(this.hashSettings)
       this.highestId = parseInt(highestId)
       return oldHash && oldHash !== newHash
     } else {

--- a/src/lib/strategies/Default.ts
+++ b/src/lib/strategies/Default.ts
@@ -37,7 +37,6 @@ export default class SyncProcess {
   protected server: TAdapter
   protected cacheTreeRoot: Folder<typeof ItemLocation.LOCAL>|null
   protected canceled: boolean
-  protected preserveOrder: boolean
   protected progressCb: (progress:number, actionsDone?:number)=>void
 
   // Stage -1
@@ -86,8 +85,6 @@ export default class SyncProcess {
     this.mappings = mappings
     this.localTree = localTree
     this.server = server
-
-    this.preserveOrder = 'orderFolder' in this.server
 
     this.progressCb = throttle(500, true, progressCb) as (progress:number, actionsDone?:number)=>void
     this.canceled = false

--- a/src/lib/strategies/Merge.ts
+++ b/src/lib/strategies/Merge.ts
@@ -22,7 +22,7 @@ export default class MergeSyncProcess extends DefaultSyncProcess {
         }
         return false
       },
-      this.preserveOrder,
+      this.hashSettings,
       false,
       false
     )
@@ -36,7 +36,7 @@ export default class MergeSyncProcess extends DefaultSyncProcess {
         }
         return false
       },
-      this.preserveOrder,
+      this.hashSettings,
       false,
       false
     )
@@ -97,7 +97,7 @@ export default class MergeSyncProcess extends DefaultSyncProcess {
             }
             return false
           },
-          this.preserveOrder,
+          this.hashSettings,
           false,
           false
         )

--- a/src/lib/strategies/Unidirectional.ts
+++ b/src/lib/strategies/Unidirectional.ts
@@ -62,7 +62,7 @@ export default class UnidirectionalSyncProcess extends DefaultStrategy {
         }
         return false
       },
-      this.preserveOrder,
+      this.hashSettings,
       false,
       false
     )
@@ -87,7 +87,7 @@ export default class UnidirectionalSyncProcess extends DefaultStrategy {
         }
         return false
       },
-      this.preserveOrder,
+      this.hashSettings,
       false,
       false
     )

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -68,7 +68,7 @@ describe('Floccus', function() {
   this.slow(20000) // 20s is slow
 
   const params = (new URL(window.location.href)).searchParams
-  let SERVER, CREDENTIALS, ACCOUNTS, APP_VERSION, SEED, BROWSER, RANDOM_MANIPULATION_ITERATIONS, TEST_URL, IS_CI
+  let SERVER, CREDENTIALS, ACCOUNTS, APP_VERSION, SEED, BROWSER, RANDOM_MANIPULATION_ITERATIONS, TEST_URL
   SERVER =
     params.get('server') ||
     'http://localhost'

--- a/src/test/test.js
+++ b/src/test/test.js
@@ -8674,6 +8674,8 @@ async function getAllBookmarks(account) {
 async function withSyncConnection(account, fn) {
   const adapter = account.server
   if (adapter.onSyncStart) await adapter.onSyncStart()
+  const capabilities = await adapter.getCapabilities()
+  if (adapter.setHashSettings) adapter.setHashSettings({preserveOrder: capabilities.preserveOrder, hashFn: capabilities.hashFn[0]})
   await fn()
   if (adapter.onSyncComplete) await adapter.onSyncComplete()
 }


### PR DESCRIPTION
for tree hashing

|Fake adapter benchmark on Firefox (~5k bookmarks)|Murmur3|sha256|
|-|-|-|
|should handle deep hierarchies with lots of bookmarks|62.782s|70.387s|
|should handle fuzzed changes from one client|126.245s|150.305s|
|should handle fuzzed changes from two clients|239.926s|267.662s|