### PR TITLE
Add custom http header option when adding WebDav server for security.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -140,6 +140,12 @@
   "DescriptionWebdavurl": {
     "message": "e.g. with nextcloud: https://example.com/remote.php/webdav/"
   },
+  "LabelCustomHeaders": {
+    "message": "Custom Headers"
+  },
+  "DescriptionCustomHeaders": {
+    "message": "Optional: Add custom headers in key:value format, one per line. These will be added to all WebDAV requests."
+  },
   "LabelNextcloudurl": {
     "message": "Nextcloud URL"
   },

--- a/_locales/zh_CN/messages.json
+++ b/_locales/zh_CN/messages.json
@@ -137,6 +137,12 @@
   "DescriptionWebdavurl": {
     "message": "例如使用 NextCloud：https://your-domain.com/remote.php/webdav/"
   },
+    "LabelCustomHeaders": {
+    "message": "自定义header"
+  },
+  "DescriptionCustomHeaders": {
+    "message": "可选：添加自定义 header 键值对，类似key1:value1, 每行一个。这些 header 将被添加到所有 WebDAV 请求中。"
+  },
   "LabelNextcloudurl": {
     "message": "Nextcloud URL"
   },

--- a/src/lib/adapters/WebDav.ts
+++ b/src/lib/adapters/WebDav.ts
@@ -48,6 +48,7 @@ export default class WebDavAdapter extends CachingAdapter {
       allowRedirects: false,
       passphrase: '',
       allowNetwork: false,
+      customHeaders: {},
     }
   }
 
@@ -166,7 +167,8 @@ export default class WebDavAdapter extends CachingAdapter {
             method: 'DELETE',
             credentials: 'omit',
             headers: {
-              Authorization: 'Basic ' + authString
+              Authorization: 'Basic ' + authString,
+              ...(this.server.customHeaders || {}),
             },
             signal: this.abortSignal,
             ...(!this.server.allowRedirects && {redirect: 'manual'}),
@@ -176,7 +178,8 @@ export default class WebDavAdapter extends CachingAdapter {
             url: fullUrl,
             method: 'DELETE',
             headers: {
-              Authorization: 'Basic ' + authString
+              Authorization: 'Basic ' + authString,
+              ...(this.server.customHeaders || {}),
             },
             webFetchExtra: {
               credentials: 'omit',
@@ -397,7 +400,8 @@ export default class WebDavAdapter extends CachingAdapter {
         method: 'PUT',
         headers: {
           'Content-Type': content_type,
-          Authorization: 'Basic ' + authString
+          Authorization: 'Basic ' + authString,
+          ...(this.server.customHeaders || {})
         },
         credentials: 'omit',
         signal: this.abortSignal,
@@ -432,7 +436,8 @@ export default class WebDavAdapter extends CachingAdapter {
         method: 'PUT',
         headers: {
           'Content-Type': content_type,
-          Authorization: 'Basic ' + authString
+          Authorization: 'Basic ' + authString,
+          ...(this.server.customHeaders || {})
         },
         data
       })
@@ -476,6 +481,7 @@ export default class WebDavAdapter extends CachingAdapter {
         headers: {
           Authorization: 'Basic ' + authString,
           Depth: '0',
+          ...(this.server.customHeaders || {}),
         },
         cache: 'no-store',
         credentials: 'omit',
@@ -517,7 +523,8 @@ export default class WebDavAdapter extends CachingAdapter {
           Authorization: 'Basic ' + authString,
           Depth: '0',
           Pragma: 'no-cache',
-          'Cache-Control': 'no-cache'
+          'Cache-Control': 'no-cache',
+          ...(this.server.customHeaders || {}),
         },
         responseType: 'text'
       })
@@ -548,7 +555,8 @@ export default class WebDavAdapter extends CachingAdapter {
       res = await fetch(url,{
         method: 'GET',
         headers: {
-          Authorization: 'Basic ' + authString
+          Authorization: 'Basic ' + authString,
+          ...(this.server.customHeaders || {})
         },
         cache: 'no-store',
         credentials: 'omit',
@@ -587,7 +595,8 @@ export default class WebDavAdapter extends CachingAdapter {
         headers: {
           Authorization: 'Basic ' + authString,
           Pragma: 'no-cache',
-          'Cache-Control': 'no-cache'
+          'Cache-Control': 'no-cache',
+          ...(this.server.customHeaders || {})
         },
         responseType: 'text'
       })

--- a/src/ui/components/OptionsWebdav.vue
+++ b/src/ui/components/OptionsWebdav.vue
@@ -23,6 +23,16 @@
           :rules="[validateUrl]"
           :label="t('LabelWebdavurl')"
           @input="$emit('update:url', $event)" />
+        <v-textarea
+          :value="customHeadersText"
+          class="mt-2"
+          :label="t('LabelCustomHeaders')"
+          :hint="t('DescriptionCustomHeaders')"
+          :persistent-hint="true"
+          rows="3"
+          auto-grow
+          placeholder="Authorization=Bearer token&#10;X-Custom-Header=value"
+          @input="onCustomHeadersInput" />
         <v-text-field
           :value="username"
           :label="t('LabelUsername')"
@@ -159,12 +169,29 @@ import OptionSyncIntervalEnabled from './OptionSyncIntervalEnabled.vue'
 export default {
   name: 'OptionsWebdav',
   components: { OptionSyncIntervalEnabled, OptionAutoSync, OptionExportBookmarks, OptionAllowNetwork, OptionDownloadLogs, OptionAllowRedirects, OptionClientCert, OptionFailsafe, OptionSyncFolder, OptionDeleteAccount, OptionSyncStrategy, OptionResetCache, OptionSyncInterval, OptionNestedSync, OptionFileType, OptionPassphrase },
-  props: ['url', 'username', 'password','passphrase', 'includeCredentials', 'serverRoot', 'localRoot', 'allowNetwork', 'syncInterval', 'strategy', 'bookmark_file', 'nestedSync', 'failsafe', 'allowRedirects', 'bookmark_file_type', 'enabled', 'label', 'syncIntervalEnabled'],
+  props: ['url', 'username', 'password','passphrase', 'includeCredentials', 'serverRoot', 'localRoot', 'allowNetwork', 'syncInterval', 'strategy', 'bookmark_file', 'nestedSync', 'failsafe', 'allowRedirects', 'bookmark_file_type', 'enabled', 'label', 'syncIntervalEnabled', 'customHeaders'],
   data() {
     return {
       panels: [0, 1],
       showPassword: false,
       showPassphrase: false,
+    }
+  },
+  computed: {
+    customHeadersText: {
+      get() {
+        if (!this.customHeaders) return ''
+        if (typeof this.customHeaders === 'string') return this.customHeaders
+        if (typeof this.customHeaders === 'object') {
+          return Object.entries(this.customHeaders)
+            .map(([key, value]) => `${key}=${value}`)
+            .join('\n')
+        }
+        return ''
+      },
+      set(value) {
+        this.$emit('update:customHeaders', value)
+      }
     }
   },
   methods: {
@@ -179,6 +206,9 @@ export default {
     validateBookmarksFile(path) {
       return path[0] !== '/' && path[path.length - 1] !== '/'
     },
+    onCustomHeadersInput(value) {
+      this.customHeadersText = value
+    }
   }
 }
 </script>

--- a/src/ui/store/actions.js
+++ b/src/ui/store/actions.js
@@ -112,18 +112,20 @@ export const actionsDefinition = {
   async [actions.DOWNLOAD_LOGS]({ commit, dispatch, state }, anonymous) {
     await Logger.downloadLogs(anonymous)
   },
-  async [actions.TEST_WEBDAV_SERVER]({commit, dispatch, state}, {rootUrl, username, password}) {
+  async [actions.TEST_WEBDAV_SERVER]({commit, dispatch, state}, {rootUrl, username, password, customHeaders = {}}) {
     await dispatch(actions.REQUEST_NETWORK_PERMISSIONS)
+    const headers = {
+      'User-Agent': 'Floccus bookmarks sync',
+      Depth: '0',
+      Authorization: 'Basic ' + Base64.encode(
+        username + ':' + password
+      ),
+      ...customHeaders
+    }
     let res = await fetch(`${rootUrl}`, {
       method: 'PROPFIND',
       credentials: 'omit',
-      headers: {
-        'User-Agent': 'Floccus bookmarks sync',
-        Depth: '0',
-        Authorization: 'Basic ' + Base64.encode(
-          username + ':' + password
-        )
-      }
+      headers: headers
     })
     if (res.status < 200 || res.status > 299) {
       throw new Error('Could not connect to your webdav server at the specified URL. The server responded with HTTP status ' + res.status + ' to a PROPFIND request with Basic Auth on the URL you entered.')

--- a/src/ui/views/NewAccount.vue
+++ b/src/ui/views/NewAccount.vue
@@ -235,6 +235,15 @@
                 :append-icon="showPassphrase ? 'mdi-eye' : 'mdi-eye-off'"
                 :type="showPassphrase ? 'text' : 'password'"
                 @click:append="showPassphrase = !showPassphrase" />
+              <v-textarea
+                v-model="customHeaders"
+                class="mt-2"
+                :label="t('LabelCustomHeaders')"
+                :hint="t('DescriptionCustomHeaders')"
+                :persistent-hint="true"
+                rows="3"
+                auto-grow
+                placeholder="Authorization=Bearer token&#10;X-Custom-Header=value" />
             </v-form>
             <div class="form-buttons">
               <v-btn @click="currentStep--">
@@ -513,6 +522,7 @@ export default {
       showPassphrase: false,
       clickCountEnabled: false,
       label: '',
+      customHeaders: '',
       adapter: 'nextcloud-bookmarks',
       adapters: [
         {
@@ -585,6 +595,7 @@ export default {
         ...(this.adapter === 'google-drive' && {refreshToken: this.refreshToken}),
         ...(this.passphrase && {passphrase: this.passphrase}),
         ...(this.adapter === 'google-drive' && this.passphrase && {password: this.passphrase}),
+        ...(this.adapter === 'webdav' && this.customHeaders && {customHeaders: this.parseCustomHeaders()}),
         ...(this.isBrowser && {localRoot: this.localRoot}),
         syncInterval: this.syncInterval,
         strategy: this.strategy,
@@ -637,7 +648,14 @@ export default {
       this.isServerTestRunning = true
       this.serverTestError = ''
       try {
-        await this.$store.dispatch(actions.TEST_WEBDAV_SERVER, {rootUrl: this.server, username: this.username, password: this.password})
+        const customHeaders = this.parseCustomHeaders()
+        console.log('debug customerHeader:', customHeaders)
+        await this.$store.dispatch(actions.TEST_WEBDAV_SERVER, {
+          rootUrl: this.server,
+          username: this.username,
+          password: this.password,
+          customHeaders
+        })
         this.serverTestSuccessful = true
         this.currentStep++
       } catch (e) {
@@ -688,6 +706,23 @@ export default {
     },
     validateBookmarksFileGoogle(path) {
       return !path.includes('/')
+    },
+    parseCustomHeaders() {
+      const headers = {}
+      if (!this.customHeaders.trim()) return headers
+
+      const lines = this.customHeaders.split('\n')
+      lines.forEach(line => {
+        const trimmedLine = line.trim()
+        if (trimmedLine && trimmedLine.includes(':')) {
+          const [key, ...valueParts] = trimmedLine.split(':')
+          const value = valueParts.join(':').trim()
+          if (key.trim() && value) {
+            headers[key.trim()] = value
+          }
+        }
+      })
+      return headers
     },
     requestHistoryPermissions() {
       this.$store.dispatch(actions.REQUEST_HISTORY_PERMISSIONS)


### PR DESCRIPTION
this is my first time for creating a pull request, thanks for reading.

floccus is a good tool for self-hosted user.

i use floccus with my self-hosted webdav server, which is running in laptop at home remotely, and use cloudflare's tunnel feature to expose the internal network. you can add custom header(token) validation for security. so if someone doesn't have right header token , she/he will not connect to this webdav server.

i want this feature added into floccus, so please check my code. some translate work is incomplete, i only translate english and my mother tongue.