### PR TITLE
Fix typo in messages.json

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -9,7 +9,7 @@
     "message": "E003: Der Ordner, aus dem verschoben werden soll, existiert nicht. Dies ist eine Anomalie. Herzlichen Glückwunsch."
   },
   "Error004": {
-    "message": ".E004: Der Ordner, in den verschoben werden soll, existiert nicht"
+    "message": "E004: Der Ordner, in den verschoben werden soll, existiert nicht."
   },
   "Error005": {
     "message": "E005: Der Ordner, in dem erzeugt werden soll, existiert nicht."


### PR DESCRIPTION
I was searching for a settings schema.json in the _locales and came across the german translation because I wanted to mange extension settings via policies then I saw this and really gave me an OCD.