### PR TITLE
fix(localization): Update Karakeep description to clarify supported protocols

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -198,7 +198,7 @@
     "message": "Beim Synchronisieren werden deine Lesezeichen in diesem Browser als Links in dieser Kollektion in Linkwarden gespeichert und nur Links in dieser Kollektion werden mit diesem Browser synchronisiert."
   },
   "DescriptionServerfolderkarakeep": {
-    "message": "Beim Synchronisieren werden deine Lesezeichen in diesem Browser als Links in dieser Kollektion in KaraKeep gespeichert und nur Links in dieser Kollektion werden mit diesem Browser synchronisiert."
+    "message": "Beim Synchronisieren werden deine Lesezeichen in diesem Browser als Links in dieser Kollektion in Karakeep gespeichert und nur Links in dieser Kollektion werden mit diesem Browser synchronisiert."
   },
   "LabelLocaltarget": {
     "message": "Lokales Ziel"
@@ -865,25 +865,25 @@
     "message": "Wenn du zu einem konkreten Problem direkt die Entwickler kontaktieren möchtest, dann kannst du das hier tun:"
   },
   "LabelAdapterKarakeep":  {
-    "message": "KaraKeep"
+    "message": "Karakeep"
   },
   "DescriptionAdapterKarakeep":  {
-    "message": "Synchronisieren Sie Ihre Lesezeichen mit der Open-Source selbst-gehosteten KaraKeep Anwendung. Diese Option unterstützt keine Ende-zu-Ende-Verschlüsselung und kann nicht die Reihenfolge Ihrer Lesezeichen synchronisieren."
+    "message": "Synchronisieren Sie Ihre Lesezeichen mit der Open-Source selbst-gehosteten Karakeep Anwendung. Es werden nur http-Lesezeichen synchronisiert. Diese Option unterstützt keine Ende-zu-Ende-Verschlüsselung und kann nicht die Reihenfolge Ihrer Lesezeichen synchronisieren."
   },
   "LabelApiKey":  {
     "message": "API-Schlüssel"
   },
   "LabelKarakeepurl":  {
-    "message": "Die URL Ihres KaraKeep-Servers"
+    "message": "Die URL Ihres Karakeep-Servers"
   },
   "LabelKarakeepconnectionerror": {
-    "message": "Verbindung zu KaraKeep-Server konnte nicht hergestellt werden"
+    "message": "Verbindung zu Karakeep-Server konnte nicht hergestellt werden"
   },
   "LabelAdapterlinkwarden":  {
     "message": "Linkwarden"
   },
   "DescriptionAdapterlinkwarden":  {
-    "message": "Synchronisieren SIe Ihre Lesezeichen mit der quelloffenen Linkwarden App, die auf deinem Server oder in der Cloud über cloud.linkwarden.app gehostet ist. Linkwarden kann nur http-, ftp- oder javascript-Lesezeichen synchronisieren. Diese Option unterstützt keine Ende-zu-Ende-Verschlüsselung und kann nicht die Reihenfolge Ihrer Lesezeichen synchronisieren."
+    "message": "Synchronisieren Sie Ihre Lesezeichen mit der quelloffenen Linkwarden App, die auf deinem Server oder in der Cloud über cloud.linkwarden.app gehostet ist. Linkwarden kann nur http-, ftp- oder javascript-Lesezeichen synchronisieren. Diese Option unterstützt keine Ende-zu-Ende-Verschlüsselung und kann nicht die Reihenfolge Ihrer Lesezeichen synchronisieren."
   },
   "LabelLinkwardenurl":  {
     "message": "Die URL deines Linkwarden-Servers"

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -868,7 +868,7 @@
     "message": "Karakeep"
   },
   "DescriptionAdapterKarakeep":  {
-    "message": "Sync your bookmarks with the open-source self-hosted Karakeep app. This option cannot make use of end-to-end encryption and does not support keeping the order of bookmarks across syncs."
+    "message": "Sync your bookmarks with the open-source self-hosted Karakeep app. It can only sync http bookmarks. This option cannot make use of end-to-end encryption and does not support keeping the order of bookmarks across syncs."
   },
   "LabelApiKey":  {
     "message": "API key"


### PR DESCRIPTION
fix(localization): typos

The Karakeep interface only implements http and https. See https://github.com/floccusaddon/floccus/blob/f1aff8a314986f9b47be45bb4322a62a7a9f70a4/src/lib/adapters/Karakeep.ts#L66-L72

The info message currently has no indication of that.

> [!NOTE]
> I am using `http` instead of `http(s)` for the description to be consistent with existing localizations.

Also fixed the brand name: `KaraKeep` > `Karakeep` in German localization. See: [Karakeep - The Bookmark Everything App](https://karakeep.app/)

Related discussion: https://github.com/floccusaddon/floccus/discussions/2258#discussioncomment-17201740
