### PR TITLE
Open settings in new tab to allow file access on mobile

### DIFF
--- a/manifest.firefox.json
+++ b/manifest.firefox.json
@@ -25,7 +25,8 @@
 
   "options_ui": {
     "page": "dist/html/options.html",
-    "browser_style": false
+    "browser_style": false,
+    "open_in_tab": true
   },
 
   "browser_action": {


### PR DESCRIPTION
For Gecko mobile it is necessary to launch extension settings in a dedicated main browser tab instead of the stripped down gecko view for extensions to allow device interactions like file access.

Fixes: https://github.com/FaFre/WebLibre/issues/445

Reference: https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/manifest.json/options_ui

This will affect desktop usage - when opening "Preferences" in `about:addons` instead of the currently embedded settings a new tab will be opened. 