### PR TITLE
fix: fix issues 2303 RequestInit contains non ISO-8859-1 code point.

### DIFF
--- a/src/lib/adapters/WebDav.ts
+++ b/src/lib/adapters/WebDav.ts
@@ -77,7 +77,7 @@ export default class WebDavAdapter extends CachingAdapter {
   }
 
   getBookmarkURL() {
-    return this.normalizeServerURL(this.server.url) + this.server.bookmark_file
+    return this.normalizeServerURL(this.server.url) + encodeURIComponent(this.server.bookmark_file)
   }
 
   getBookmarkLockURL() {


### PR DESCRIPTION
We need to URL-encode bookmark_file inside getBookmarkURL(), or sanitize destinationUrl with encodeURI() in moveFileWeb.
修复方向：在 getBookmarkURL () 中对 bookmark_file 做 URL 编码，或者在 moveFileWeb 中使用 encodeURI () 处理 destinationUrl

#2303 