### PR TITLE
fix: fix issues 2303 RequestInit contains non ISO-8859-1 code point.

### DIFF
--- a/src/lib/adapters/WebDav.ts
+++ b/src/lib/adapters/WebDav.ts
@@ -615,7 +615,7 @@ export default class WebDavAdapter extends CachingAdapter {
         credentials: this.server.includeCredentials ? 'include' : 'omit',
         headers: {
           Authorization: 'Basic ' + authString,
-          Destination: destinationUrl,
+          Destination: encodeURI(destinationUrl),
           Overwrite: 'T',
         },
         signal: this.abortSignal,
@@ -650,7 +650,7 @@ export default class WebDavAdapter extends CachingAdapter {
         method: 'MOVE',
         headers: {
           Authorization: 'Basic ' + authString,
-          Destination: destinationUrl,
+          Destination: encodeURI(destinationUrl),
           Overwrite: 'T',
         },
         disableRedirects: !this.server.allowRedirects,


### PR DESCRIPTION
Perform URL encoding on destinationUrl to make non-ASCII characters valid inside HTTP headers.
对 destinationUrl 进行 URL 编码，确保非 ASCII 字符在 HTTP 头中合法。

#2303 