### PR TITLE
Support nested serverFolder paths with automatic creation

### DIFF
--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -5,6 +5,7 @@ import { ICapabilities, IHashSettings, IResource } from '../interfaces/Resource'
 import Logger from '../Logger'
 import {
   AuthenticationError,
+  UnknownFolderUpdateError,
   CancelledSyncError, HttpError, MissingPermissionsError,
   NetworkError, ParseResponseError,
   RedirectError,
@@ -244,10 +245,13 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     if (!rootCollection) {
       const segments = this.server.serverFolder.split('/').filter(seg => seg.length > 0)
 
+      if (segments.length === 0) {
+        throw new UnknownFolderUpdateError()
+      }
       let currentParentId = null
       let current = null
 
-       for (const segment of segments) {
+      for (const segment of segments) {
         const expectedParent = currentParentId == null ? null : String(currentParentId)
 
         current = collections.find(collection => {

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -253,36 +253,28 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
 
       for (const segment of segments) {
         const expectedParent = currentParentId == null ? null : String(currentParentId)
-
         current = collections.find(collection => {
           const actualParent = collection.parentId == null ? null : String(collection.parentId)
           return collection.name === segment && actualParent === expectedParent
         })
-
-
         if (!current) {
-          const body: any = { name: segment }
+          const body: { name: string; parentId?: string | number } = { name: segment }
           if (currentParentId != null) {
             body.parentId = currentParentId
           }
-
           ({ response: current } = await this.sendRequest(
             'POST', '/api/v1/collections',
             'application/json',
             body
           ))
-
           collections.push(current)
         }
-
         currentParentId = current.id
-      }
-
+      }      
       if (current) {
         rootCollection = current
       }
     }
-    
 
     const buildTree = (collection, isRoot = false) => {
       const collectionId = String(collection.id)

--- a/src/lib/adapters/Linkwarden.ts
+++ b/src/lib/adapters/Linkwarden.ts
@@ -240,14 +240,45 @@ export default class LinkwardenAdapter implements Adapter, IResource<typeof Item
     const { response: collections } = await this.sendRequest('GET', `/api/v1/collections`)
 
     let rootCollection = collections.find(collection => collection.name === this.server.serverFolder && collection.parentId == null)
+
     if (!rootCollection) {
-      ({response: rootCollection} = await this.sendRequest(
-        'POST', '/api/v1/collections',
-        'application/json',
-        {
-          name: this.server.serverFolder,
-        }))
+      const segments = this.server.serverFolder.split('/').filter(seg => seg.length > 0)
+
+      let currentParentId = null
+      let current = null
+
+       for (const segment of segments) {
+        const expectedParent = currentParentId == null ? null : String(currentParentId)
+
+        current = collections.find(collection => {
+          const actualParent = collection.parentId == null ? null : String(collection.parentId)
+          return collection.name === segment && actualParent === expectedParent
+        })
+
+
+        if (!current) {
+          const body: any = { name: segment }
+          if (currentParentId != null) {
+            body.parentId = currentParentId
+          }
+
+          ({ response: current } = await this.sendRequest(
+            'POST', '/api/v1/collections',
+            'application/json',
+            body
+          ))
+
+          collections.push(current)
+        }
+
+        currentParentId = current.id
+      }
+
+      if (current) {
+        rootCollection = current
+      }
     }
+    
 
     const buildTree = (collection, isRoot = false) => {
       const collectionId = String(collection.id)


### PR DESCRIPTION
## Summary

This PR extends how the `serverFolder` is resolved when building the
bookmarks tree.

Until now, the code only looked for a single top-level collection whose
name exactly matched `serverFolder`. If none was found, it created one
flat root collection. Nested folder paths were not supported.

## Changes

- **Exact match first:** Keeps the existing behavior of matching the full
  `serverFolder` name against a root-level collection.
- **Path resolution fallback:** If no exact match exists, `serverFolder`
  is split on `/` and each segment is resolved sequentially from the root
  downwards. The parent of each segment must be the previously matched
  collection.
- **Auto-creation of missing segments:** Any segment that does not yet
  exist is created via `POST /api/v1/collections` (with the correct
  `parentId`) and added to the local collection list so `buildTree` can
  use it.
- **isRoot handling:** The deepest (target) collection is always passed to
  `buildTree` with `isRoot = true`.

## Behavior

| Case | Result |
|------|--------|
| Full name exists as root | Used directly |
| Path partially exists (e.g. `a/b` exists, `c` missing) | `a`, `b` reused, `c` created |
| Path does not exist at all | All segments created sequentially |

## Notes

- Parent comparisons are normalized to strings to avoid number/string
  mismatches.
