### PR TITLE
Android - NativeStorage patch applied

### DIFF
--- a/src/lib/native/NativeAccountStorage.js
+++ b/src/lib/native/NativeAccountStorage.js
@@ -1,4 +1,4 @@
-import { Preferences as Storage } from '@capacitor/preferences'
+import NativeStorage from './NativeStorage'
 import Cryptography from '../Crypto'
 import DefunctCryptography from '../DefunctCrypto'
 import Mappings from '../Mappings'
@@ -18,18 +18,18 @@ export default class NativeAccountStorage {
       let entry = await NativeAccountStorage.getEntry(entryName, defaultVal)
       entry = fn(entry)
 
-      await Storage.set({ key: entryName, value: JSON.stringify(entry) })
+      await NativeStorage.set(entryName, entry)
     })
   }
 
   static async getEntry(entryName, defaultVal) {
-    let entry = await Storage.get({key: entryName })
+    let entry = await NativeStorage.get(entryName)
     try {
-      if (entry.value) {
-        if (typeof entry.value === 'string') {
-          entry.value = JSON.parse(entry.value)
+      if (entry !== undefined) {
+        if (typeof entry === 'string') {
+          entry = JSON.parse(entry)
         }
-        return entry.value
+        return entry
       } else {
         return defaultVal
       }
@@ -41,7 +41,7 @@ export default class NativeAccountStorage {
   }
 
   static deleteEntry(entryName) {
-    return Storage.remove({key: entryName})
+    return NativeStorage.remove(entryName)
   }
 
   static async getAllAccounts() {

--- a/src/lib/native/NativeStorage.js
+++ b/src/lib/native/NativeStorage.js
@@ -1,0 +1,62 @@
+import { Preferences as LegacyStorage } from '@capacitor/preferences'
+
+const DB_NAME = 'floccus-native-storage'
+const DB_VERSION = 1
+const STORE_NAME = 'entries'
+
+let dbPromise
+
+function getDb() {
+  if (!dbPromise) {
+    dbPromise = new Promise((resolve, reject) => {
+      const request = indexedDB.open(DB_NAME, DB_VERSION)
+      request.onupgradeneeded = () => request.result.createObjectStore(STORE_NAME)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+  }
+  return dbPromise
+}
+
+export default class NativeStorage {
+  static async get(key) {
+    const db = await getDb()
+    const value = await new Promise((resolve, reject) => {
+      const request = db.transaction(STORE_NAME, 'readonly').objectStore(STORE_NAME).get(key)
+      request.onsuccess = () => resolve(request.result)
+      request.onerror = () => reject(request.error)
+    })
+
+    if (value !== undefined) return value
+
+    // Migrate existing Capacitor Preferences data lazily, one key at a time.
+    const legacy = await LegacyStorage.get({key})
+    if (!legacy.value) return undefined
+
+    let migratedValue = legacy.value
+    try {
+      migratedValue = JSON.parse(legacy.value)
+    } catch (_) {}
+
+    await NativeStorage.set(key, migratedValue)
+    return migratedValue
+  }
+
+  static async set(key, value) {
+    const db = await getDb()
+    return new Promise((resolve, reject) => {
+      const request = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).put(value, key)
+      request.onsuccess = () => resolve()
+      request.onerror = () => reject(request.error)
+    })
+  }
+
+  static async remove(key) {
+    const db = await getDb()
+    return new Promise((resolve, reject) => {
+      const request = db.transaction(STORE_NAME, 'readwrite').objectStore(STORE_NAME).delete(key)
+      request.onsuccess = () => resolve()
+      request.onerror = () => reject(request.error)
+    })
+  }
+}

--- a/src/lib/native/NativeTree.ts
+++ b/src/lib/native/NativeTree.ts
@@ -1,4 +1,4 @@
-import { Preferences as Storage } from '@capacitor/preferences'
+import NativeStorage from './NativeStorage'
 import { Bookmark, Folder, ItemLocation, TItemLocation } from '../Tree'
 import Ordering from '../interfaces/Ordering'
 import CachingAdapter from '../adapters/Caching'
@@ -20,8 +20,8 @@ export default class NativeTree extends CachingAdapter implements BulkImportReso
   }
 
   async load():Promise<boolean> {
-    const {value: tree} = await Storage.get({key: `bookmarks[${this.accountId}].tree`})
-    const {value: highestId} = await Storage.get({key: `bookmarks[${this.accountId}].highestId`})
+    const tree = await NativeStorage.get(`bookmarks[${this.accountId}].tree`)
+    const highestId = await NativeStorage.get(`bookmarks[${this.accountId}].highestId`)
     if (tree) {
       // Make sure we use xxhash3 if we have to calculate hash for this
       const hashSettings: IHashSettings = {
@@ -32,7 +32,7 @@ export default class NativeTree extends CachingAdapter implements BulkImportReso
       if (this.loaded && this.bookmarksCache) {
         oldHash = await this.bookmarksCache.cloneWithLocation(false, this.location).hash(hashSettings)
       }
-      this.bookmarksCache = Folder.hydrate(JSON.parse(tree)).copy(false)
+      this.bookmarksCache = Folder.hydrate(typeof tree === 'string' ? JSON.parse(tree) : tree).copy(false)
       const parsedHighestId = parseInt(highestId ?? '0', 10)
       this.highestId = Number.isNaN(parsedHighestId) ? 0 : parsedHighestId
       if (oldHash && this.loaded) {
@@ -50,8 +50,11 @@ export default class NativeTree extends CachingAdapter implements BulkImportReso
   }
 
   async save():Promise<void> {
-    await Storage.set({key: `bookmarks[${this.accountId}].tree`, value: JSON.stringify(await this.bookmarksCache.cloneWithLocation(true, ItemLocation.LOCAL).toJSONAsync())})
-    await Storage.set({key: `bookmarks[${this.accountId}].highestId`, value: this.highestId + ''})
+    await NativeStorage.set(
+      `bookmarks[${this.accountId}].tree`,
+      await this.bookmarksCache.cloneWithLocation(true, ItemLocation.LOCAL).toJSONAsync()
+    )
+    await NativeStorage.set(`bookmarks[${this.accountId}].highestId`, this.highestId + '')
   }
 
   triggerSave():void {


### PR DESCRIPTION
Strongly improve android native app sync performance, especially the first sync of a new profile which could fail for medium-big size of bookmarks.

Mods:
- local android storage replaced with IndexedDB; 
- maintained compatibility with existing data via automatic migration from Preferences; 
- eliminated the passing of massive JSON strings across the Capacitor bridge; 
- retained Preferences solely as a migration source;
- avoided the introducing SQLite or native code at this stage.